### PR TITLE
feat (Config/cookies): Adjust reading Configuration settings, add Cookie SameSiteMode property.

### DIFF
--- a/PasswordlessLogin/Configuration/Options/MailOptions.cs
+++ b/PasswordlessLogin/Configuration/Options/MailOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace SimpleIAM.PasswordlessLogin.Configuration
+{
+    public class MailOptions
+    {
+        public string FromEmail { get; set; } = "from.address@not.configured";
+        public string FromDisplayName { get; set; } = PasswordlessLoginConstants.DefaultDisplayName;
+        public SmtpOptions Smtp { get; set; }
+    }
+}

--- a/PasswordlessLogin/Configuration/Options/PasswordlessLoginOptions.cs
+++ b/PasswordlessLogin/Configuration/Options/PasswordlessLoginOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
+using SameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode;
 
 namespace SimpleIAM.PasswordlessLogin.Configuration
 {
@@ -12,8 +13,6 @@ namespace SimpleIAM.PasswordlessLogin.Configuration
             Urls = new UrlOptions();
         }
 
-        public string EmailFrom { get; set; } = "from.address@not.configured";
-        public string DisplayName { get; set; } = PasswordlessLoginConstants.DefaultDisplayName;
         public string[] IdpUserClaims { get; set; } = new string[] { };
         public string IdpUserNameClaim { get; set; } = "email";
         public int DefaultSessionLengthMinutes { get; set; } = PasswordlessLoginConstants.Security.DefaultDefaultSessionLengthMinutes;
@@ -33,5 +32,8 @@ namespace SimpleIAM.PasswordlessLogin.Configuration
         public bool NonceRequiredOnUntrustedBrowser { get; set; } = true;
         public UrlOptions Urls { get; set; }
         public IDictionary<string, string> CustomProperties { get; set; }
+        public SameSiteMode CookieSameSiteMode { get; set; } = SameSiteMode.Unspecified;
+
+        public MailOptions Mail { get; set; } = new MailOptions();
     }
 }

--- a/PasswordlessLogin/Configuration/Options/SmtpOptions.cs
+++ b/PasswordlessLogin/Configuration/Options/SmtpOptions.cs
@@ -10,5 +10,6 @@ namespace SimpleIAM.PasswordlessLogin.Configuration
         public string Username { get; set; } = "";
         public string Password { get; set; } = "";
         public bool UseSsl { get; set; } = true;
+        public bool UseAuthentication { get; set; } = true;
     }
 }

--- a/PasswordlessLogin/Configuration/Options/SmtpOptions.cs
+++ b/PasswordlessLogin/Configuration/Options/SmtpOptions.cs
@@ -10,6 +10,9 @@ namespace SimpleIAM.PasswordlessLogin.Configuration
         public string Username { get; set; } = "";
         public string Password { get; set; } = "";
         public bool UseSsl { get; set; } = true;
+        /// <summary>
+        /// Use the configured Username and Password to authenticate with the SMTP server, otherwise no auth is attempted (typically anonymous).
+        /// </summary>
         public bool UseAuthentication { get; set; } = true;
     }
 }

--- a/PasswordlessLogin/Extensions/PasswordlessLoginServiceCollectionExtensions.cs
+++ b/PasswordlessLogin/Extensions/PasswordlessLoginServiceCollectionExtensions.cs
@@ -1,34 +1,10 @@
 ﻿// Copyright (c) Ryan Foster. All rights reserved. 
 // Licensed under the Apache License, Version 2.0.
 
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
-using Microsoft.AspNetCore.Mvc.Routing;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.FileProviders;
 using SimpleIAM.PasswordlessLogin;
 using SimpleIAM.PasswordlessLogin.Configuration;
-using SimpleIAM.PasswordlessLogin.Entities;
-using SimpleIAM.PasswordlessLogin.Helpers;
-using SimpleIAM.PasswordlessLogin.Orchestrators;
-using SimpleIAM.PasswordlessLogin.Services;
-using SimpleIAM.PasswordlessLogin.Services.Email;
-using SimpleIAM.PasswordlessLogin.Services.EventNotification;
-using SimpleIAM.PasswordlessLogin.Services.Message;
-using SimpleIAM.PasswordlessLogin.Services.OTC;
-using SimpleIAM.PasswordlessLogin.Services.Password;
-using SimpleIAM.PasswordlessLogin.Stores;
 using System;
-using System.IO;
-using System.Net;
-using System.Reflection;
-using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -46,9 +22,9 @@ namespace Microsoft.Extensions.DependencyInjection
         public static PasswordlessLoginBuilder AddPasswordlessLogin(this IServiceCollection services, IConfiguration configuration)
         {
             var passwordlessLoginOptions = new PasswordlessLoginOptions();
-            configuration.Bind(passwordlessLoginOptions);
+            configuration.GetSection(PasswordlessLoginConstants.ConfigurationSections.IdProvider).Bind(passwordlessLoginOptions);
             var builder = new PasswordlessLoginBuilder(services, passwordlessLoginOptions);
-            return builder.AddPasswordlessLogin();
+            return builder.AddPasswordlessLogin(configuration);
         }
     }
 }

--- a/PasswordlessLogin/PasswordlessLogin.csproj
+++ b/PasswordlessLogin/PasswordlessLogin.csproj
@@ -48,7 +48,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.11" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.11" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan" Version="3.5.3">
       <PrivateAssets>all</PrivateAssets>

--- a/PasswordlessLogin/PasswordlessLogin.csproj
+++ b/PasswordlessLogin/PasswordlessLogin.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.8.0" />
+    <PackageReference Include="MailKit" Version="2.10.1" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="3.1.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.5">

--- a/PasswordlessLogin/PasswordlessLoginConstants.cs
+++ b/PasswordlessLogin/PasswordlessLoginConstants.cs
@@ -8,7 +8,6 @@ namespace SimpleIAM.PasswordlessLogin
     public static class PasswordlessLoginConstants
     {
         public const string DefaultDisplayName = "Passwordless Login";
-
         public const string BasicEmailRegexPattern = @".+\@.+\..+";
         public const string EmailTemplateFolder = "EmailTemplates";
 
@@ -16,9 +15,9 @@ namespace SimpleIAM.PasswordlessLogin
         {
             public const string IdProvider = "IdProvider";
             public const string PasswordlessDatabase = "PasswordlessDatabase";
-            public const string MailFrom = "Mail:From";
-            public const string Smtp = "Mail:Smtp";
+            public const string Smtp = "IdProvider:Mail:Smtp";
             public const string ConnectionStringName = "DefaultConnection";
+            public const string Mail = "IDProvider:Mail";
         }
 
         public static class EmailTemplates

--- a/PasswordlessLogin/Services/Email/EmailAddress.cs
+++ b/PasswordlessLogin/Services/Email/EmailAddress.cs
@@ -1,0 +1,8 @@
+﻿namespace SimpleIAM.PasswordlessLogin.Services.Email
+{
+    public class EmailAddress
+    {
+        public string Email { get; set; }
+        public string DisplayName { get; set; }
+    }
+}

--- a/PasswordlessLogin/Services/Email/IEmailService.cs
+++ b/PasswordlessLogin/Services/Email/IEmailService.cs
@@ -8,6 +8,6 @@ namespace SimpleIAM.PasswordlessLogin.Services.Email
 {
     public interface IEmailService
     {
-        Task<Status> SendEmailAsync(string from, string to, string subject, string body);
+        Task<Status> SendEmailAsync(EmailAddress from, string to, string subject, string body);
     }
 }

--- a/PasswordlessLogin/Services/Email/LoggerEmailService.cs
+++ b/PasswordlessLogin/Services/Email/LoggerEmailService.cs
@@ -16,10 +16,11 @@ namespace SimpleIAM.PasswordlessLogin.Services.Email
             _logger = logger;
         }
 
-        public async Task<Status> SendEmailAsync(string from, string to, string subject, string body)
+        public async Task<Status> SendEmailAsync(EmailAddress from, string to, string subject, string body)
         {
             _logger.LogInformation("Sending email to log (sensitive info not redacted, use only in dev)");
-            _logger.LogInformation("From: {0}\r\nTo: {1}\r\nSubject: {2}\r\nBody:\r\n{3}", from, to, subject, body);
+            _logger.LogInformation("From: {0}\r\nTo: {1}\r\nSubject: {2}\r\nBody:\r\n{3}", from.Email, to, subject,
+                body);
             return Status.Success("Email sent.");
         }
     }

--- a/PasswordlessLogin/Services/Email/SmtpEmailService.cs
+++ b/PasswordlessLogin/Services/Email/SmtpEmailService.cs
@@ -59,8 +59,11 @@ namespace SimpleIAM.PasswordlessLogin.Services.Email
                 {
                     _logger.LogDebug("Connecting to {0}:{1} ({2})", _smtpOptions.Server, _smtpOptions.Port, _smtpOptions.UseSsl ? "ssl" : "not ssl");
                     await client.ConnectAsync(_smtpOptions.Server, _smtpOptions.Port, _smtpOptions.UseSsl);
-                    _logger.LogDebug("Authenticating with SMTP server");
-                    await client.AuthenticateAsync(_smtpOptions.Username, _smtpOptions.Password);
+                    if (_smtpOptions.UseAuthentication)
+                    {
+                        _logger.LogDebug("Authenticating with SMTP server");
+                        await client.AuthenticateAsync(_smtpOptions.Username, _smtpOptions.Password);
+                    }
                     _logger.LogDebug("Sending message");
                     await client.SendAsync(message);
                 }

--- a/PasswordlessLogin/Services/Email/SmtpEmailService.cs
+++ b/PasswordlessLogin/Services/Email/SmtpEmailService.cs
@@ -26,14 +26,19 @@ namespace SimpleIAM.PasswordlessLogin.Services.Email
             _smtpOptions = smtpOptions;
         }
 
-        public async Task<Status> SendEmailAsync(string from, string to, string subject, string body)
+        public async Task<Status> SendEmailAsync(EmailAddress from, string to, string subject, string body)
         {
             _logger.LogDebug("Sending email to {0} with subject {1}", to, subject);
-            var message = new MimeMessage()
+            var message = new MimeMessage
             {                
                 Subject = subject
             };
-            message.From.Add(MailboxAddress.Parse(from));
+            var fromAddress = MailboxAddress.Parse(from.Email);
+            if (!string.IsNullOrEmpty(from.DisplayName))
+            {
+                fromAddress.Name = from.DisplayName;
+            }
+            message.From.Add(fromAddress);
             message.To.Add(MailboxAddress.Parse(to));
             if (body?.Contains("</") == true || body?.Contains("/>") == true)
             {


### PR DESCRIPTION
refactor (config): Move SMTP/Mail config under config node "IdProvider", isolate config properties when using inside another 
feat (email): Add FromDisplayName to config
feat (config): Add config option to set Cookie SameSiteMode.  Useful in development when you run a SPA on different port non SSL, and backend is SSL,  (may need to set SameSiteMode to None in this example since SSL<->NonSSL triggers CORS)
fix (config/email): Bind from Config, previously SmtpSettings were not binding the config properties.
feat (email): Set the DisplayName for From address in outbound mail.

Patch builds on PR #10

Note: This will break the Vue Example code, but I can do a PR for that repo to match this commit.